### PR TITLE
Remove duplicate link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ This system will enable:
 
 * [SPECIFICATION.md](SPECIFICATION.md)
 * [ARCHITECTURE.md](ARCHITECTURE.md)
-* [SPECIFICATION.md](SPECIFICATION.md)
-* [ARCHITECTURE.md](ARCHITECTURE.md)
 
 ## Assignment 5:
 - [Use Case Diagrams.md](./Use%20Case%20Diagram.md)


### PR DESCRIPTION
I noticed that the same links appears twice in the same sections (_SPECIFICATION.md_ and _ARCHITECTURE.md_) of the README.  
This PR removes the duplicate to improve readability and avoid confusion.  