### PR TITLE
Fix Mermaid diagram rendering in ARCHITECTURE.md and Use Case Diagram.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,3 +11,4 @@ C4Context
     Rel(member, librarySystem, "Uses")
     Rel(librarySystem, database, "Stores and retrieves data")
     Rel(librarySystem, digitalContent, "Stores and retrieves digital content")
+```

--- a/Use Case Diagram.md
+++ b/Use Case Diagram.md
@@ -68,3 +68,4 @@ graph TD
         Security -->|Protects User Data| Database["🗄️ Secure Database"]
 
     end
+```


### PR DESCRIPTION
This PR corrects the formatting of mermaid code blocks by adding the closing ``` markers in two markdown files:

ARCHITECTURE.md

Use Case Diagram.md

Without these closing symbols, the diagrams were not rendering properly. Now, they are displayed correctly in markdown viewers that support Mermaid.